### PR TITLE
docs: correct CJIS v6.0 audit timeline to phased rollout

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -105,7 +105,7 @@ This script supports the FedRAMP 20x compliance-as-code direction by producing d
 
 ## CJIS v6.0 Relevance
 
-CJIS v6.0 became the audit standard on April 1, 2026 and aligns with NIST 800-53 Rev 5 as of December 2024. The most material delta this script touches is **SC-28**: CJIS v6.0 requires encryption at rest using **agency-managed Customer Master Keys (CMKs)** for buckets storing CJI. AWS-managed encryption (AES-256 / SSE-S3) satisfies FedRAMP High SC-28 but does **not** satisfy CJIS v6.0 — agencies must provision their own KMS CMKs and configure SSE-KMS with those CMKs. A future enhancement to this script will report the encryption *key source* (not just whether encryption is on) to surface this delta during an audit.
+CJIS Security Policy v6.0 (published Dec 27, 2024) aligns to NIST 800-53 Rev 5 and phases in rather than switching on a single date: v5.9.5 was the scored audit standard through March 31, 2026 and v6.0 is the default audit baseline from April 1, 2026, with modernized Priority 2-4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA). The most material delta this script touches is **SC-28**: CJIS v6.0 requires encryption at rest using **agency-managed Customer Master Keys (CMKs)** for buckets storing CJI. AWS-managed encryption (AES-256 / SSE-S3) satisfies FedRAMP High SC-28 but does **not** satisfy CJIS v6.0 — agencies must provision their own KMS CMKs and configure SSE-KMS with those CMKs. A future enhancement to this script will report the encryption *key source* (not just whether encryption is on) to surface this delta during an audit.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Corrects the CJIS v6.0 audit-timeline language from a single-cutover framing ("v6.0 becomes/became the audit standard on April 1, 2026") to the verified phased rollout.
- Phased framing: v5.9.5 was the scored audit standard through March 31, 2026; v6.0 is the default audit baseline from April 1, 2026; modernized Priority 2–4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA).
- Surrounding control content (AU-6 / SC-28 / delta mappings) preserved verbatim.

## Why
The April 1, 2026 date is the default go-forward audit baseline, not a one-day enforcement cutover. The corrected framing matches the FBI CJIS v6.0 phased rollout.

## Test Plan
- [x] Dates cross-checked against the canonical reconciled CJIS v6.0 timeline
- [x] Grep sweep — zero residual single-cutover phrasing in tracked files

Factual documentation correction — no issue.