### PR TITLE
docs: add architecture overview diagram and editable Mermaid source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ Two scripts:
 1. **`s3_audit.py`** — Audits buckets for encryption and public access block compliance.
 2. **`deploy_test_buckets.py`** — Creates test buckets with various configurations to exercise the audit script.
 
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    CLI["s3_audit.py<br/>CLI entry"] --> S3["boto3 S3 client"]
+    S3 --> LIST["list_buckets"]
+    LIST --> PER["Per-bucket checks"]
+    PER --> ENC["get_bucket_encryption<br/>SSE-KMS / AES-256"]
+    PER --> PAB["get_public_access_block<br/>all four settings"]
+    FIX["deploy_test_buckets.py<br/>optional fixtures"] -.-> S3
+    ENC --> OUT["Console summary evidence<br/>PASS / WARN / FAIL"]
+    PAB --> OUT
+    OUT --> HUM["Auditors / assessors"]
+    OUT --> PIPE["Future CSV/JSON<br/>evidence-logger · OSCAL"]
+```
+
+Editable Mermaid source (kept in sync with the fence above): [`docs/architecture.mmd`](docs/architecture.mmd).
+
+`s3_audit.py` lists every bucket, then checks encryption-at-rest (SC-28) and public access block (AC-3 / CM-6) per bucket. Findings print as a console PASS/WARN/FAIL summary for assessors today; CSV/JSON export is the planned handoff into evidence-logger / OSCAL. `deploy_test_buckets.py` is an optional fixture path for local exercise.
+
 ## Requirements
 
 - Python 3.x

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,14 @@
+%% Editable Mermaid source for the README "Architecture Overview" section.
+%% Keep this file in sync with the inline ```mermaid fence in README.md.
+%% Diff-able source of truth for the architecture graph (no separate PNG export).
+flowchart TD
+    CLI["s3_audit.py<br/>CLI entry"] --> S3["boto3 S3 client"]
+    S3 --> LIST["list_buckets"]
+    LIST --> PER["Per-bucket checks"]
+    PER --> ENC["get_bucket_encryption<br/>SSE-KMS / AES-256"]
+    PER --> PAB["get_public_access_block<br/>all four settings"]
+    FIX["deploy_test_buckets.py<br/>optional fixtures"] -.-> S3
+    ENC --> OUT["Console summary evidence<br/>PASS / WARN / FAIL"]
+    PAB --> OUT
+    OUT --> HUM["Auditors / assessors"]
+    OUT --> PIPE["Future CSV/JSON<br/>evidence-logger · OSCAL"]


### PR DESCRIPTION
## Summary
- Add an **Architecture Overview** section to the README: a Mermaid flowchart of the audit data flow — `s3_audit.py` → boto3 S3 client → `list_buckets` → per-bucket `get_bucket_encryption` (SC-28) + `get_public_access_block` (AC-3 / CM-6) → console PASS/WARN/FAIL evidence summary → assessors, with the planned CSV/JSON handoff toward `evidence-logger` / OSCAL drawn as an explicitly future node
- Add `docs/architecture.mmd` — diff-able, editable Mermaid source kept byte-identical with the README fence (diagram-as-code; no PNG export to go stale)
- Route the `deploy_test_buckets.py` fixtures edge to the S3 client/account state it actually mutates (dotted `-.-> S3`), not the CLI
- Normalize `README.MD` → `README.md`

Documentation-only: no audit or control logic changed.

## Test Plan
- [x] README fence and `docs/architecture.mmd` graph bodies verified byte-identical
- [x] Every diagram node verified against source symbols (`list_buckets`, `get_bucket_encryption`, `get_public_access_block`, PASS/WARN/FAIL summary)
- [ ] Mermaid fence renders correctly on GitHub